### PR TITLE
fix: Fix mismatched column definitions

### DIFF
--- a/database/migrations/2019_12_21_000000_create_categories_table.php
+++ b/database/migrations/2019_12_21_000000_create_categories_table.php
@@ -21,7 +21,7 @@ class CreateCategoriesTable extends Migration
             $table->string('cover')->nullable();
             $table->unsignedInteger('status')->default(0);
 
-            $table->integer('parent_id')->unsigned()->nullable()->index();
+            $table->unsignedBigInteger('parent_id')->nullable()->index();
             $table->foreign('parent_id')->references('id')->on('categories');
             $table->integer('left')->unsigned()->nullable()->index();
             $table->integer('right')->unsgined()->nullable()->index();

--- a/database/migrations/2020_01_13_000000_create_orders_table.php
+++ b/database/migrations/2020_01_13_000000_create_orders_table.php
@@ -15,7 +15,7 @@ class CreateOrdersTable extends Migration
     {
         Schema::create('orders', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->string('cart_id')->unique()->index();
+            $table->unsignedBigInteger('cart_id')->unique()->index();
             $table->unsignedBigInteger('customer_id')->index()->nullable();
             #$table->unsignedBigInteger('address_id')->index()->nullable();
             #$table->unsignedInteger('order_status_id')->index();


### PR DESCRIPTION
The mismatched types were causing key failures when running migrations.