### PR TITLE
fix: Reconcile lingering Cart/Order/Product discrepancies

### DIFF
--- a/database/factories/OrderFactory.php
+++ b/database/factories/OrderFactory.php
@@ -1,13 +1,13 @@
 <?php
 
-use IndieHD\Velkart\Contracts\Repositories\Eloquent\CartRepositoryContract;
 use IndieHD\Velkart\Contracts\Repositories\Eloquent\OrderRepositoryContract;
+use IndieHD\Velkart\Contracts\Repositories\Eloquent\OrderStatusRepositoryContract;
 
 $order = resolve(OrderRepositoryContract::class);
-$cart = resolve(CartRepositoryContract::class);
+$orderStatus = resolve(OrderStatusRepositoryContract::class);
 
-$factory->define($order->modelClass(), function (Faker\Generator $faker) use ($cart) {
+$factory->define($order->modelClass(), function (Faker\Generator $faker) use ($orderStatus) {
     return [
-        'cart_id' => factory($cart->modelClass())->create()->id,
+        'order_status_id' => factory($orderStatus->modelClass())->create()->id,
     ];
 });

--- a/database/migrations/2020_01_13_000000_create_orders_table.php
+++ b/database/migrations/2020_01_13_000000_create_orders_table.php
@@ -15,7 +15,7 @@ class CreateOrdersTable extends Migration
     {
         Schema::create('orders', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->unsignedBigInteger('cart_id')->unique()->index();
+            $table->unsignedBigInteger('order_status_id')->index();
             $table->unsignedBigInteger('customer_id')->index()->nullable();
             //$table->unsignedBigInteger('address_id')->index()->nullable();
             //$table->unsignedInteger('order_status_id')->index();
@@ -27,9 +27,8 @@ class CreateOrdersTable extends Migration
                 ))->on(config('velkart.user_table', 'users'));
             }
 
-            $table->foreign('cart_id')->references('id')->on('carts');
             //$table->foreign('address_id')->references('id')->on('addresses');
-            //$table->foreign('order_status_id')->references('id')->on('order_statuses');
+            $table->foreign('order_status_id')->references('id')->on('order_statuses');
             $table->timestamps();
         });
     }

--- a/database/migrations/2020_01_13_000001_create_order_products_table.php
+++ b/database/migrations/2020_01_13_000001_create_order_products_table.php
@@ -16,6 +16,7 @@ class CreateOrderProductsTable extends Migration
         Schema::create('order_product', function (Blueprint $table) {
             $table->unsignedBigInteger('order_id')->index();
             $table->unsignedBigInteger('product_id')->index();
+            $table->unsignedBigInteger('price');
 
             $table->foreign('order_id')->references('id')->on('orders');
             $table->foreign('product_id')->references('id')->on('products');

--- a/src/Models/Eloquent/Cart.php
+++ b/src/Models/Eloquent/Cart.php
@@ -13,12 +13,4 @@ class Cart extends Model
     {
         parent::__construct($attributes);
     }
-
-    /**
-     * @return HasOne
-     */
-    public function order()
-    {
-        return $this->hasOne(Order::class);
-    }
 }

--- a/src/Models/Eloquent/Order.php
+++ b/src/Models/Eloquent/Order.php
@@ -15,14 +15,7 @@ class Order extends Model
      */
     public function products(): BelongsToMany
     {
-        return $this->belongsToMany(Product::class);
-    }
-
-    /**
-     * @return BelongsTo
-     */
-    public function cart(): BelongsTo
-    {
-        return $this->belongsTo(Cart::class);
+        return $this->belongsToMany(Product::class)
+            ->withPivot('price');
     }
 }

--- a/src/Models/Eloquent/Product.php
+++ b/src/Models/Eloquent/Product.php
@@ -47,6 +47,7 @@ class Product extends Model implements Buyable
      */
     public function orders(): BelongsToMany
     {
-        return $this->belongsToMany(Order::class);
+        return $this->belongsToMany(Order::class)
+            ->withPivot('price');
     }
 }

--- a/tests/Feature/Repositories/CartRepositoryTest.php
+++ b/tests/Feature/Repositories/CartRepositoryTest.php
@@ -167,17 +167,4 @@ class CartRepositoryTest extends TestCase
             ['identifier' => $model->identifier]
         );
     }
-
-    /** @test */
-    public function itHasOneOrder()
-    {
-        $cart = factory($this->getRepository()->modelClass())->create();
-
-        $cart->order()->save(factory($this->order->modelClass())->make());
-
-        $this->assertInstanceOf(
-            $this->order->modelClass(),
-            $cart->order
-        );
-    }
 }

--- a/tests/Feature/Repositories/CartTest.php
+++ b/tests/Feature/Repositories/CartTest.php
@@ -85,17 +85,4 @@ class CartTest extends TestCase
 
         $this->assertEquals($identifier, $cart->identifier);
     }
-
-    /** @test */
-    public function itHasOneOrder()
-    {
-        $cart = factory($this->getRepository()->modelClass())->create();
-
-        $cart->order()->save(factory($this->order->modelClass())->make());
-
-        $this->assertInstanceOf(
-            $this->order->modelClass(),
-            $cart->order
-        );
-    }
 }

--- a/tests/Feature/Repositories/ProductTest.php
+++ b/tests/Feature/Repositories/ProductTest.php
@@ -95,8 +95,9 @@ class ProductTest extends RepositoryTestCase
 
         $orders = factory($this->order->modelClass(), 2)->create();
 
-        $product->orders()->save($orders->shift());
-        $product->orders()->save($orders->shift());
+        $orders->each(function ($order) use ($product) {
+            $product->orders()->attach($order->id, ['price' => $product->price]);
+        });
 
         $this->assertInstanceOf(Collection::class, $product->orders);
 


### PR DESCRIPTION
Primarily, this commit eliminates the relationship between Order and
Cart, because Carts are ephemeral and could be destroyed at any time
(and thus, an Order should never depend on a Cart, nor vice versa).