### PR TITLE
fix: Remove deprecated loadFactoriesFrom() call

### DIFF
--- a/src/VelkartServiceProvider.php
+++ b/src/VelkartServiceProvider.php
@@ -37,7 +37,6 @@ class VelkartServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
-        $this->loadFactoriesFrom(__DIR__.'/../database/factories');
         $this->loadRoutesFrom(__DIR__.'/../routes/api.php');
 
         $this->publishes([


### PR DESCRIPTION
Apparently, this method has been deprecated in Laravel 8, and will be removed in a future version. Removing it now seems to have no side-effects.