### PR TITLE
chore: Update baum/baum to Laravel 8 compatible version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,16 +14,10 @@
   ],
   "minimum-stability": "dev",
   "prefer-stable": true,
-  "repositories": [
-    {
-      "type": "vcs",
-      "url": "https://github.com/ChrisThompsonTLDR/baum.git"
-    }
-  ],
   "require": {
     "bumbummen99/shoppingcart": "^2.0",
-    "baum/baum": "v2.x-dev#a5944ebfd605688213954fd19e1aff0e8fafb132",
-    "illuminate/support": "^8.0"
+    "illuminate/support": "^8.0",
+    "baum/baum": "v2.x-dev"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Remove forked repository in favor of original, which now has a dev
branch that adds Laravel 8 support.