### PR TITLE
ci: fix depreciated warnings in travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: php
+dist: xenial
+os: linux
 
 php:
   - '7.3'
@@ -6,8 +8,6 @@ php:
 
 addons:
   mariadb: '10.3'
-
-sudo: false
 
 before_script:
   - COMPOSER_MEMORY_LIMIT=-1 travis_retry composer install --prefer-dist --no-interaction


### PR DESCRIPTION
Removed: deprecated key sudo (The key `sudo` has no effect anymore.)
Added: missing dist
Added: missing os

closes issue #43